### PR TITLE
Fix spellprac detection issues in th08

### DIFF
--- a/TouhouRPC/games/Touhou08.cpp
+++ b/TouhouRPC/games/Touhou08.cpp
@@ -86,8 +86,8 @@ void Touhou08::readDataFromGameProcess()
     ReadProcessMemory(processHandle, (LPCVOID)MENU_MODE, (LPVOID)&menuMode, 4, NULL);
     // menu mode being 2 implies we're in-game
 
-    char stageMode = 0;
-    ReadProcessMemory(processHandle, (LPCVOID)STAGE_MODE, (LPVOID)&stageMode, 1, NULL);
+    unsigned int stageMode = 0;
+    ReadProcessMemory(processHandle, (LPCVOID)STAGE_MODE, (LPVOID)&stageMode, 4, NULL);
 
     if (menuMode != 2 || (stageMode & STAGE_MODE_DEMO_FLAG) != 0)
     {

--- a/TouhouRPC/games/Touhou08.cpp
+++ b/TouhouRPC/games/Touhou08.cpp
@@ -87,9 +87,17 @@ void Touhou08::readDataFromGameProcess()
     ReadProcessMemory(processHandle, (LPCVOID)STAGE_MODE, (LPVOID)&stageMode, 4, NULL);
 
     // SPELL_CARD_ID
-    ReadProcessMemory(processHandle,
-        (LPCVOID)(stageMode & STAGE_MODE_SPELL_PRACTICE_FLAG ? SPELLPRAC_CARD_ID : SPELL_CARD_ID),
-        (LPVOID)&spellCardID, 4, NULL);
+    // Technically this is not needed and it could just always read the id into a 4-byte var (initialized to 0 beforehand),
+    // but reading 2 byte values into a 2 byte variable and 4 byte values into 4 byte variables just... makes more sense.
+    UINT32 spellIdNormal;
+    UINT16 spellIdSpellprac;
+    if (stageMode & STAGE_MODE_SPELL_PRACTICE_FLAG) {
+        ReadProcessMemory(processHandle, (LPVOID)SPELLPRAC_CARD_ID, &spellIdSpellprac, sizeof(spellIdSpellprac), NULL);
+        spellCardID = spellIdSpellprac;
+    } else {
+        ReadProcessMemory(processHandle, (LPVOID)SPELL_CARD_ID, &spellIdNormal, sizeof(spellIdNormal), NULL);
+        spellCardID = spellIdNormal;
+    }
 
     if (menuMode != 2 || (stageMode & STAGE_MODE_DEMO_FLAG) != 0)
     {

--- a/TouhouRPC/games/Touhou08.cpp
+++ b/TouhouRPC/games/Touhou08.cpp
@@ -110,10 +110,7 @@ void Touhou08::readDataFromGameProcess()
 
     if (state.gameState == GameState::Playing)
     {
-        char bgm_playing[1];
-        ReadProcessMemory(processHandle, (LPCVOID)BGM_STR_1, bgm_playing, 1, NULL);
-
-        if ((stageMode & STAGE_MODE_SPELL_PRACTICE_FLAG) != 0 || bgm_playing[0] != 'b')
+        if ((stageMode & STAGE_MODE_SPELL_PRACTICE_FLAG) != 0)
         {
             state.gameState = GameState::SpellPractice;
         }

--- a/TouhouRPC/games/Touhou08.cpp
+++ b/TouhouRPC/games/Touhou08.cpp
@@ -79,15 +79,17 @@ void Touhou08::readDataFromGameProcess()
         bossStateChange++;
     }
 
-    // SPELL_CARD_ID
-    ReadProcessMemory(processHandle, (LPCVOID)SPELL_CARD_ID, (LPVOID)&spellCardID, 1, NULL);
-
     unsigned int menuMode = 0;
     ReadProcessMemory(processHandle, (LPCVOID)MENU_MODE, (LPVOID)&menuMode, 4, NULL);
     // menu mode being 2 implies we're in-game
 
     unsigned int stageMode = 0;
     ReadProcessMemory(processHandle, (LPCVOID)STAGE_MODE, (LPVOID)&stageMode, 4, NULL);
+
+    // SPELL_CARD_ID
+    ReadProcessMemory(processHandle,
+        (LPCVOID)(stageMode & STAGE_MODE_SPELL_PRACTICE_FLAG ? SPELLPRAC_CARD_ID : SPELL_CARD_ID),
+        (LPVOID)&spellCardID, 4, NULL);
 
     if (menuMode != 2 || (stageMode & STAGE_MODE_DEMO_FLAG) != 0)
     {

--- a/TouhouRPC/games/Touhou08.h
+++ b/TouhouRPC/games/Touhou08.h
@@ -95,7 +95,7 @@ private:
 		STAGE_MODE_DEMO_FLAG = 2,
 		STAGE_MODE_PAUSE_FLAG = 4,
 		STAGE_MODE_REPLAY_FLAG = 8,
-		STAGE_MODE_SPELL_PRACTICE_FLAG = 128,
+		STAGE_MODE_SPELL_PRACTICE_FLAG = 0x4000,
 
 		PLAYER_POINTER         = 0x0160F510L, // score at offset 00 (int); lives at offset 74 (float); bombs at offset 80 (float); game overs offset 28 (byte)
 	};

--- a/TouhouRPC/games/Touhou08.h
+++ b/TouhouRPC/games/Touhou08.h
@@ -80,7 +80,7 @@ private:
 
 		// unlike the one above, this is set before the spell begins in spellprac
 		// (probably used by ECL script to tell which spell to even start)
-		SPELLPRAC_CARD_ID      = 0x0164D0B8,
+		SPELLPRAC_CARD_ID      = 0x0164D0B8, // 2 bytes
 
 		STAGE_FRAMES           = 0x0164D0AC,
 		MUSIC_ROOM_CURSOR      = 0x017CF53CL,

--- a/TouhouRPC/games/Touhou08.h
+++ b/TouhouRPC/games/Touhou08.h
@@ -76,7 +76,12 @@ private:
 		SCORE                  = 0x0160F510,
 		STAGE                  = 0x004E4850,
 		BOSS_APPEARANCE        = 0x018B89B8, // 1 byte
-		SPELL_CARD_ID          = 0x004EA678, // 1 byte
+		SPELL_CARD_ID          = 0x004EA678, // 4 bytes (even if only 1 byte is used, the game writes/reads it as dword)
+
+		// unlike the one above, this is set before the spell begins in spellprac
+		// (probably used by ECL script to tell which spell to even start)
+		SPELLPRAC_CARD_ID      = 0x0164D0B8,
+
 		STAGE_FRAMES           = 0x0164D0AC,
 		MUSIC_ROOM_CURSOR      = 0x017CF53CL,
 		MUSIC_ROOM_TRACK       = 0x017CF540L, // the actually playing track

--- a/TouhouRPC/games/Touhou08.h
+++ b/TouhouRPC/games/Touhou08.h
@@ -78,7 +78,6 @@ private:
 		BOSS_APPEARANCE        = 0x018B89B8, // 1 byte
 		SPELL_CARD_ID          = 0x004EA678, // 1 byte
 		STAGE_FRAMES           = 0x0164D0AC,
-		BGM_STR_1              = 0x018BCB70, // set to stage music when normally playing, or the current music when in spell practice. in spell practice, "bgm/" is missing
 		MUSIC_ROOM_CURSOR      = 0x017CF53CL,
 		MUSIC_ROOM_TRACK       = 0x017CF540L, // the actually playing track
 


### PR DESCRIPTION
Apart from fixing the issue I described in #6, now flag 0x4000 is used instead of 128 to check whether spell practice is active. The difference from 128 is that it's always set when in spellprac mode, even when the spell is not active yet (and as far as I can tell, flag 0x4000 is how the game determines whether to load spell practice ECL files in the first place - in fact, that's how I found it).  Apart from that, now a spellprac-specific spell ID variable is used when in spell practice - this one is set before the spell even begins. I believe the ECL scripts use this value to determine which spell to even start (not tested but likely). 

The result of these changes is that both correct spell ID and spell practice being active are always detected as soon as spell practice starts.