### PR TITLE
add th18 trial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Make sure the *discord_game_sdk.dll* file is in the same folder as the *TouhouRP
 - Touhou 15 - Legacy of Lunatic Kingdom
 - Touhou 16 - Hidden Stars in Four Seasons
 - Touhou 17 - Wily Beast and Weakest Creature
+- Touhou 18 - Unconnected Marketeer - Trial
 
 If you want to see other games or fangames supported, contributions are welcome!
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Make sure the *discord_game_sdk.dll* file is in the same folder as the *TouhouRP
 - Touhou 15 - Legacy of Lunatic Kingdom
 - Touhou 16 - Hidden Stars in Four Seasons
 - Touhou 17 - Wily Beast and Weakest Creature
-- Touhou 18 - Unconnected Marketeer - Trial
+- Touhou 18 - Unconnected Marketeers - Trial (v0.02a)
 
 If you want to see other games or fangames supported, contributions are welcome!
 

--- a/TouhouRPC/GameDetector.cpp
+++ b/TouhouRPC/GameDetector.cpp
@@ -69,6 +69,7 @@ std::unique_ptr<TouhouBase> initializeTouhouGame(bool initLogSilence)
         case SupportedGame::LoLK_15:    thGame = std::make_unique<Touhou15::Touhou15>(pe32); break;
         case SupportedGame::HSiFS_16:   thGame = std::make_unique<Touhou16::Touhou16>(pe32); break;
         case SupportedGame::WBaWC_17:   thGame = std::make_unique<Touhou17::Touhou17>(pe32); break;
+        case SupportedGame::UM_18_Trial:thGame = std::make_unique<Touhou18::Touhou18Trial>(pe32); break;
 
         case SupportedGame::Invalid:
         {

--- a/TouhouRPC/GameDetector.h
+++ b/TouhouRPC/GameDetector.h
@@ -24,6 +24,7 @@
 #include "games/Touhou15.h"
 #include "games/Touhou16.h"
 #include "games/Touhou17.h"
+#include "games/Touhou18.h"
 
 enum class SupportedGame
 {
@@ -42,6 +43,7 @@ enum class SupportedGame
 	LoLK_15,
 	HSiFS_16,
 	WBaWC_17,
+	UM_18_Trial,
 
 	Invalid,
 };
@@ -52,7 +54,7 @@ struct ProcessNameGamePair
 	const wchar_t* processName;
 };
 
-const int PROCESS_NAME_LIST_SIZE = 21;
+const int PROCESS_NAME_LIST_SIZE = 23;
 
 // Executables name list and associated game
 static const ProcessNameGamePair processNameList[PROCESS_NAME_LIST_SIZE] =
@@ -78,6 +80,8 @@ static const ProcessNameGamePair processNameList[PROCESS_NAME_LIST_SIZE] =
 	{ SupportedGame::LoLK_15, L"th15.exe" },
 	{ SupportedGame::HSiFS_16, L"th16.exe" },
 	{ SupportedGame::WBaWC_17, L"th17.exe" },
+	{ SupportedGame::UM_18_Trial, L"th18.exe"},
+	{ SupportedGame::UM_18_Trial, L"th18tr.exe"},
 };
 
 std::unique_ptr<TouhouBase> initializeTouhouGame(bool initLogSilence = false);

--- a/TouhouRPC/TouhouRPC.cpp
+++ b/TouhouRPC/TouhouRPC.cpp
@@ -102,7 +102,7 @@ void startDisplay() {
     cout << "Usage: Once started, the program will automatically attach to a Touhou game currently running on the computer." << endl;
     cout << "The program automatically detects when you change betwen supported games." << endl;
     cout << "You can close this program at any time by pressing (Ctrl+C)." << endl;
-    cout << "Supported games: Touhou 06 (EoSD), 07 (PCB), 08 (IN), 09 (PoFV), 09.5 (StB), 10 (MoF), 11 (SA), 12 (UFO), 12.8 (GFW), 13 (TD), 14 (DDC), 14.3 (ISC), 15 (LoLK), 16 (HSiFS), 17 (WBaWC)." << endl;
+    cout << "Supported games: Touhou 06 (EoSD), 07 (PCB), 08 (IN), 09 (PoFV), 09.5 (StB), 10 (MoF), 11 (SA), 12 (UFO), 12.8 (GFW), 13 (TD), 14 (DDC), 14.3 (ISC), 15 (LoLK), 16 (HSiFS), 17 (WBaWC), 18 trial (UM)." << endl;
     cout << endl;
     
     cout << "!!THIS PROGRAM MIGHT BE ABLE TO TRIGGER ANTI-CHEAT SYSTEMS FROM OTHER GAMES, USE AT YOUR OWN RISK!!" << endl;

--- a/TouhouRPC/TouhouRPC.vcxproj
+++ b/TouhouRPC/TouhouRPC.vcxproj
@@ -185,6 +185,7 @@
     <ClCompile Include="games\Touhou15.cpp" />
     <ClCompile Include="games\Touhou16.cpp" />
     <ClCompile Include="games\Touhou17.cpp" />
+    <ClCompile Include="games\Touhou18.cpp" />
     <ClCompile Include="games\TouhouBase.cpp" />
     <ClCompile Include="games\TouhouMainGameBase.cpp" />
     <ClCompile Include="includes\discord-rpc\achievement_manager.cpp" />
@@ -224,6 +225,7 @@
     <ClInclude Include="games\Touhou15.h" />
     <ClInclude Include="games\Touhou16.h" />
     <ClInclude Include="games\Touhou17.h" />
+    <ClInclude Include="games\Touhou18.h" />
     <ClInclude Include="games\TouhouBase.h" />
     <ClInclude Include="games\TouhouMainGameBase.h" />
     <ClInclude Include="includes\discord-rpc\achievement_manager.h" />

--- a/TouhouRPC/TouhouRPC.vcxproj.filters
+++ b/TouhouRPC/TouhouRPC.vcxproj.filters
@@ -135,6 +135,9 @@
     <ClCompile Include="games\Touhou14_3.cpp">
       <Filter>Fichiers sources\game-classes</Filter>
     </ClCompile>
+    <ClCompile Include="games\Touhou18.cpp">
+      <Filter>Fichiers sources\game-classes</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="includes\discord-rpc\achievement_manager.h">
@@ -252,6 +255,9 @@
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
     <ClInclude Include="games\Touhou14_3.h">
+      <Filter>Fichiers d%27en-tête\game-classes</Filter>
+    </ClInclude>
+    <ClInclude Include="games\Touhou18.h">
       <Filter>Fichiers d%27en-tête\game-classes</Filter>
     </ClInclude>
   </ItemGroup>

--- a/TouhouRPC/games/GameStrings.h
+++ b/TouhouRPC/games/GameStrings.h
@@ -1412,3 +1412,18 @@ const std::string th17_musicNames[19] = {
 	"The Shining Law of the Strong Eating the Weak",
 	"Prince Shoutoku's Pegasus ~ Dark Pegasus",
 };
+
+// Touhou 18
+
+// Touhou 18 Music
+const std::string th18_musicNames[] = {
+	"unused",
+	"A Rainbow-Spanning Gensokyo",
+	"unused",
+	"A Shower of Strange Occurrences",
+	"Kitten of Great Fortune",
+	"The Cliff Hidden in Deep Green",
+	"Banditry Technology",
+	"The Perpetual Snow of Komakusa Blossoms",
+	"Smoking Dragon",
+};

--- a/TouhouRPC/games/Touhou18.cpp
+++ b/TouhouRPC/games/Touhou18.cpp
@@ -1,0 +1,232 @@
+#include "Touhou18.h"
+
+namespace Touhou18
+{
+
+Touhou18Trial::Touhou18Trial(PROCESSENTRY32W const& pe32) : TouhouMainGameBase(pe32)
+{
+}
+
+void Touhou18Trial::readDataFromGameProcess() {
+	menuState = -1;
+	state.gameState = GameState::Playing;
+	state.stageState = StageState::Stage;
+	gameMode = GAME_MODE_STANDARD;
+
+	// The BGM playing will be used to determine a lot of things
+	char bgm_playing[20];
+	ReadProcessMemory(processHandle, (LPCVOID)BGM_STR, bgm_playing, 20, NULL);
+
+	// Check if the game over music is playing.
+	if (std::strncmp(bgm_playing, "th128_08.wav", std::strlen("th128_08.wav")) == 0)
+	{
+		state.gameState = GameState::GameOver;
+	}
+
+	// Read stage value
+	ReadProcessMemory(processHandle, (LPCVOID)STAGE, (LPVOID)&stage, 4, NULL);
+
+	// Convert the part after the _ and before the . to int
+	// That way it is possible to switch case the BGM playing
+	bool prefixBGM = bgm_playing[0] == 'b';
+	char bgm_id_str[3];
+	bgm_id_str[0] = bgm_playing[prefixBGM ? 9 : 5];
+	bgm_id_str[1] = bgm_playing[prefixBGM ? 10 : 6];
+	bgm_id_str[2] = '\x00';
+	int bgm_id = atoi(bgm_id_str);
+
+	bgm = bgm_id;
+
+	ReadProcessMemory(processHandle, (LPCVOID)DIFFICULTY, (LPVOID)&difficulty, 4, NULL);
+	switch (difficulty)
+	{
+	default:
+	case 0: state.difficulty = Difficulty::Easy; break;
+	case 1: state.difficulty = Difficulty::Normal; break;
+	case 2: state.difficulty = Difficulty::Hard; break;
+	case 3: state.difficulty = Difficulty::Lunatic; break;
+	case 4: state.difficulty = Difficulty::Extra; break;
+	}
+
+	DWORD menu_pointer = 0;
+	ReadProcessMemory(processHandle, (LPCVOID)MENU_POINTER, (LPVOID)&menu_pointer, 4, NULL);
+	if (state.gameState == GameState::Playing && menu_pointer != 0)
+	{
+		// The most reliable way of determining our current menu state is through the combination of
+		// menu display state and extra flags that get set.
+		// This is because of a bug detailed in Touhou14's source file
+
+		/*
+			display state (0x18) -> menu screen
+			-----------------------------
+			 0 -> loading
+			 1 -> main menu
+			 5 -> game start
+			 5 -> extra start
+			 5 -> practice start
+			18 -> spell card practice
+			12 -> replay
+			10 -> player data
+			14 -> music room
+			 3 -> options
+			17 -> all manual screens
+
+			---- sub sub menus ----
+			 6 -> char select
+			 7 -> subchar select
+			 8 -> practice stage select
+			19 -> spell card select, N == num spells for stage
+			20 -> spell card difficulty select
+			12 -> replay stage select
+			11 -> player records, N == 9 on shot type, 3 on spell cards
+			23 -> achievements
+			24 -> ability cards
+		*/
+
+		DWORD ds = 0;
+		ReadProcessMemory(processHandle, (LPCVOID)(menu_pointer + 0x18), (LPVOID)&ds, 4, NULL);
+
+		switch (ds)
+		{
+		default: state.mainMenuState = MainMenuState::TitleScreen; break;
+		case 5:
+		case 6:
+		case 7: state.mainMenuState = MainMenuState::GameStart; break;
+		case 8: state.mainMenuState = MainMenuState::StagePractice; break;
+		case 18:
+		case 19:
+		case 20: state.mainMenuState = MainMenuState::SpellPractice; break;
+		case 12: state.mainMenuState = MainMenuState::Replays; break;
+		case 10:
+		case 11: state.mainMenuState = MainMenuState::PlayerData; break;
+		case 23: state.mainMenuState = MainMenuState::Achievements; break;
+		case 24: state.mainMenuState = MainMenuState::AbilityCards; break;
+		case 14: state.mainMenuState = MainMenuState::MusicRoom; break;
+		case 3: state.mainMenuState = MainMenuState::Options; break;
+		case 17: state.mainMenuState = MainMenuState::Manual; break;
+		}
+
+		menuState = 0;
+		state.gameState = GameState::MainMenu;
+	}
+
+
+	if (state.gameState == GameState::Playing)
+	{
+		// Note that ZUN's naming for the BGM file names is not very consistent
+		switch (bgm_id)
+		{
+		case 0:
+		case 1:
+			menuState = 0;
+			state.mainMenuState = MainMenuState::TitleScreen;
+			state.gameState = GameState::MainMenu;
+			break;
+		case 15: // ending
+			state.gameState = GameState::Ending;
+			break;
+		case 16: // staff roll
+			state.gameState = GameState::StaffRoll;
+			break;
+		default:
+			break;
+		}
+	}
+
+	if (state.stageState == StageState::Stage) {
+		// Enemy state object
+		// This object holds various information about general ecl state.
+		// Offset 2814h is some kind of enemy ID, which isn't consistent between runs except is always 0 when there's no boss, and non-zero when there is.
+		// Neither of these differentiate between midbosses and bosses.
+		DWORD enemy_state_ptr = 0;
+
+		ReadProcessMemory(processHandle, (LPCVOID)ENEMY_STATE_POINTER, (LPVOID)&enemy_state_ptr, 4, NULL);
+		if (enemy_state_ptr != 0)
+		{
+			DWORD enemyID = 0;
+			ReadProcessMemory(processHandle, (LPCVOID)(enemy_state_ptr + 0x2814), (LPVOID)&enemyID, 4, NULL);
+
+			if (enemyID > 0)
+			{
+				// Since music only kicks in a little bit after the boss appears, until that happens we'll be showing the midboss by accident.
+				// ... not that it's an issue except for stage 6 and EX, since otherwise all the bosses are also the midbosses.
+				// We can check a stage state number that will confirm if the boss we're looking at is midboss or not.
+
+				// Stage state.
+				// 0 -> pre-midboss + midboss
+				// 2 -> post-midboss
+				// 41 -> pre-fight appearance conversations
+				// 43 -> boss
+				// 81 -> post-boss
+				DWORD stageState = 0;
+
+				ReadProcessMemory(processHandle, (LPCVOID)STAGE_STATE, (LPVOID)&stageState, 4, NULL);
+				if (stageState == 0)
+				{
+					state.stageState = StageState::Midboss;
+				}
+				else if (stageState == 43)
+				{
+					state.stageState = StageState::Boss;
+				}
+			}
+		}
+
+	}
+
+	ReadProcessMemory(processHandle, (LPCVOID)CHARACTER, (LPVOID)&character, 4, NULL);
+	switch (character)
+	{
+	default:
+	case 0: state.character = Character::Reimu; break;
+	case 1: state.character = Character::Marisa; break;
+	case 2: state.character = Character::Sakuya; break;
+	case 3: state.character = Character::Sanae; break;
+	}
+
+	// Read current game progress
+	ReadProcessMemory(processHandle, (LPCVOID)LIVES, (LPVOID)&state.lives, 4, NULL);
+	ReadProcessMemory(processHandle, (LPCVOID)BOMBS, (LPVOID)&state.bombs, 4, NULL);
+	ReadProcessMemory(processHandle, (LPCVOID)SCORE, (LPVOID)&state.score, 4, NULL);
+	ReadProcessMemory(processHandle, (LPCVOID)GAMEOVERS, (LPVOID)&state.gameOvers, 4, NULL);
+
+	// Read game mode
+	ReadProcessMemory(processHandle, (LPCVOID)GAME_MODE, (LPVOID)&gameMode, 4, NULL);
+	switch (gameMode)
+	{
+	case GAME_MODE_STANDARD: /* could be main menu or playing, no need to overwrite anything */ break;
+	case GAME_MODE_REPLAY: state.gameState = GameState::WatchingReplay; break;
+	case GAME_MODE_CLEAR: state.gameState = GameState::StaffRoll; break;
+	case GAME_MODE_PRACTICE: state.gameState = GameState::StagePractice; break;
+	case GAME_MODE_SPELLPRACTICE: state.gameState = GameState::SpellPractice; break;
+	}
+}
+
+std::string Touhou18Trial::getMidbossName() const
+{
+	switch (stage)
+	{
+	case 1: return "Mike Goutokujiu";
+	case 2: return "Takane Yamashiro";
+	case 3: return "Sannyo Komakusa";
+	default: return "";
+	}
+}
+
+std::string Touhou18Trial::getBossName() const
+{
+	switch (stage)
+	{
+	case 1: return "Mike Goutokuji";
+	case 2: return "Takane Yamashiro";
+	case 3: return "Sannyo Komakusa";
+	default: return "";
+	}
+}
+
+std::string const& Touhou18Trial::getBGMName() const
+{
+	return th18_musicNames[bgm];
+}
+
+}

--- a/TouhouRPC/games/Touhou18.h
+++ b/TouhouRPC/games/Touhou18.h
@@ -39,20 +39,20 @@ protected:
 	bool seenMidboss{ false };
 
 private:
-	// addresses correct for v0.01b
+	// addresses correct for v0.02a
 	enum address {
-		CHARACTER                   = 0x004C0CCCL,
-		DIFFICULTY                  = 0x004C0CD8L,
-		STAGE                       = 0x004C0CB4L,
-		MENU_POINTER                = 0x004C2F2CL,
-		BGM_STR                     = 0x00543E6CL,
-		ENEMY_STATE_POINTER         = 0x004C2DD0L,
-		STAGE_STATE                 = 0x004C0CBCL,
-		LIVES                       = 0x004C0D20L,
-		BOMBS                       = 0x004C0D30L,
-		SCORE                       = 0x004C0CD4L,
-		GAMEOVERS                   = 0x004C0CDCL,
-		GAME_MODE                   = 0x004C2F28L,
+		CHARACTER                   = 0x004C112CL,
+		DIFFICULTY                  = 0x004C1138L,
+		STAGE                       = 0x004C1114L,
+		MENU_POINTER                = 0x004C338CL,
+		BGM_STR                     = 0x005442CCL,
+		ENEMY_STATE_POINTER         = 0x004C3230L,
+		STAGE_STATE                 = 0x004C111CL,
+		LIVES                       = 0x004C1180L,
+		BOMBS                       = 0x004C1190L,
+		SCORE                       = 0x004C1134L,
+		GAMEOVERS                   = 0x004C113CL,
+		GAME_MODE                   = 0x004C3388L,
 	};
 };
 

--- a/TouhouRPC/games/Touhou18.h
+++ b/TouhouRPC/games/Touhou18.h
@@ -1,0 +1,58 @@
+#pragma once
+#include "TouhouMainGameBase.h"
+#include <cstring>
+
+namespace Touhou18
+{
+
+enum GameMode
+{
+	GAME_MODE_STANDARD = 1, // main menu, endings, staff roll, and normal gameplay
+	GAME_MODE_REPLAY = 2,
+	GAME_MODE_CLEAR = 3, // seems to appear after staff roll ends, but goes back to 1 on the name registration screen.
+	GAME_MODE_PRACTICE = 4,
+	GAME_MODE_SPELLPRACTICE = 5,
+};
+
+class Touhou18Trial :
+	public TouhouMainGameBase
+{
+public:
+	Touhou18Trial(PROCESSENTRY32W const& pe32);
+
+
+	// Inherited from TouhouBase
+	int64_t getClientId() const override { return 823266075659599892; };
+	const char* getGameName() const override { return "Touhou 18 - Unconnected Marketeers - Trial"; }
+
+	void readDataFromGameProcess() override;
+
+	// Inherited from TouhouMainGameBase
+	std::string getMidbossName() const override;
+	std::string getBossName() const override;
+	std::string const& getBGMName() const override;
+
+protected:
+	int spellCardID{ -1 };
+	int gameMode{ 0 };
+	int bgm{ 1 };
+
+private:
+	// addresses correct for v0.01b
+	enum address {
+		CHARACTER                   = 0x004C0CCCL,
+		DIFFICULTY                  = 0x004C0CD8L,
+		STAGE                       = 0x004C0CB4L,
+		MENU_POINTER                = 0x004C2F2CL,
+		BGM_STR                     = 0x00543E6CL,
+		ENEMY_STATE_POINTER         = 0x004C2DA4L,
+		STAGE_STATE                 = 0x004C0CBCL,
+		LIVES                       = 0x004C0D20L,
+		BOMBS                       = 0x004C0D30L,
+		SCORE                       = 0x004C0CD4L,
+		GAMEOVERS                   = 0x004C0CDCL,
+		GAME_MODE                   = 0x004C2F28L,
+	};
+};
+
+}

--- a/TouhouRPC/games/Touhou18.h
+++ b/TouhouRPC/games/Touhou18.h
@@ -36,6 +36,7 @@ protected:
 	int spellCardID{ -1 };
 	int gameMode{ 0 };
 	int bgm{ 1 };
+	bool seenMidboss{ false };
 
 private:
 	// addresses correct for v0.01b
@@ -45,7 +46,7 @@ private:
 		STAGE                       = 0x004C0CB4L,
 		MENU_POINTER                = 0x004C2F2CL,
 		BGM_STR                     = 0x00543E6CL,
-		ENEMY_STATE_POINTER         = 0x004C2DA4L,
+		ENEMY_STATE_POINTER         = 0x004C2DD0L,
 		STAGE_STATE                 = 0x004C0CBCL,
 		LIVES                       = 0x004C0D20L,
 		BOMBS                       = 0x004C0D30L,

--- a/TouhouRPC/games/TouhouMainGameBase.cpp
+++ b/TouhouRPC/games/TouhouMainGameBase.cpp
@@ -66,6 +66,7 @@ void TouhouMainGameBase::setGameName(std::string & name) const
 		case MainMenuState::Replays: name = "Selecting a replay"; break;
 		case MainMenuState::PlayerData: name = "Viewing player data"; break;
 		case MainMenuState::Achievements: name = "Viewing achievements"; break;
+		case MainMenuState::AbilityCards: name = "Viewing ability cards"; break;
 		case MainMenuState::MusicRoom: name = "In the music room:"; break; // game info will specify track.
 		case MainMenuState::Options: name = "Changing options"; break;
 		case MainMenuState::Manual: name = "Viewing the manual"; break;

--- a/TouhouRPC/games/TouhouMainGameBase.h
+++ b/TouhouRPC/games/TouhouMainGameBase.h
@@ -35,6 +35,7 @@ enum class MainMenuState
 	Replays,
 	PlayerData,
 	Achievements,
+	AbilityCards,
 	MusicRoom,
 	Options,
 	Manual,


### PR DESCRIPTION
Adds v0.01b of th18. Code is more or less the same as th17, excluding the features disabled in the demo. There are so many ability cards I'm not sure it's worth trying to detect them (and I haven't had much luck trying to find them in memory in any case). 