### PR TITLE
fix crash on th095 when score length is less than 3

### DIFF
--- a/TouhouRPC/games/Touhou09_5.cpp
+++ b/TouhouRPC/games/Touhou09_5.cpp
@@ -152,7 +152,7 @@ std::string Touhou09_5::getCustomMenuResources() const
 
     // Formatted score 
     std::string scoreString = std::to_string(combinedPhotoScore);
-    size_t insertPosition = scoreString.length() - 3;
+    int insertPosition = scoreString.length() - 3;
     while (insertPosition > 0)
     {
         scoreString.insert(insertPosition, ",");


### PR DESCRIPTION
If `scoreString`'s length is less than 3, `insertPosition` will become a negative number, which is not allowed by `size_t` and will cause **std::out_of_range** exceptions.  

Same problem but has fixed in `createFormattedScore()`